### PR TITLE
Add ndjson encoding to OTLP HTTP exporter

### DIFF
--- a/exporter/otlphttpexporter/README.md
+++ b/exporter/otlphttpexporter/README.md
@@ -39,7 +39,7 @@ The following settings can be optionally configured:
 - `timeout` (default = 30s): HTTP request time limit. For details see https://golang.org/pkg/net/http/#Client
 - `read_buffer_size` (default = 0): ReadBufferSize for HTTP client.
 - `write_buffer_size` (default = 512 * 1024): WriteBufferSize for HTTP client.
-- `encoding` (default = proto): The encoding to use for the messages (valid options: `proto`, `json`)
+- `encoding` (default = proto): The encoding to use for the messages (valid options: `proto`, `json`, `ndjson`)
 
 Example:
 
@@ -65,6 +65,15 @@ exporters:
   otlphttp:
     ...
     encoding: json
+```
+
+To use newline delimited JSON encoding, configure as:
+
+```yaml
+exporters:
+  otlphttp:
+    ...
+    encoding: ndjson
 ```
 
 The full list of settings exposed for this exporter are documented [here](./config.go)

--- a/exporter/otlphttpexporter/config.go
+++ b/exporter/otlphttpexporter/config.go
@@ -18,8 +18,9 @@ import (
 type EncodingType string
 
 const (
-	EncodingProto EncodingType = "proto"
-	EncodingJSON  EncodingType = "json"
+	EncodingProto  EncodingType = "proto"
+	EncodingJSON   EncodingType = "json"
+	EncodingNDJSON EncodingType = "ndjson"
 )
 
 var _ encoding.TextUnmarshaler = (*EncodingType)(nil)
@@ -36,6 +37,8 @@ func (e *EncodingType) UnmarshalText(text []byte) error {
 		*e = EncodingProto
 	case string(EncodingJSON):
 		*e = EncodingJSON
+	case string(EncodingNDJSON):
+		*e = EncodingNDJSON
 	default:
 		return fmt.Errorf("invalid encoding type: %s", str)
 	}

--- a/exporter/otlphttpexporter/otlp.go
+++ b/exporter/otlphttpexporter/otlp.go
@@ -54,6 +54,7 @@ const (
 
 	jsonContentType     = "application/json"
 	protobufContentType = "application/x-protobuf"
+	ndjsonContentType   = "application/x-ndjson"
 )
 
 // Create new exporter.
@@ -98,6 +99,15 @@ func (e *baseExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
 	switch e.config.Encoding {
 	case EncodingJSON:
 		request, err = tr.MarshalJSON()
+	case EncodingNDJSON:
+		request, err = tr.MarshalJSON()
+		if err == nil {
+			// MarshalJSON does not produce unescaped newlines. Trim any
+			// whitespace just in case and append a newline delimiter for
+			// NDJSON.
+			request = bytes.TrimSpace(request)
+			request = append(request, '\n')
+		}
 	case EncodingProto:
 		request, err = tr.MarshalProto()
 	default:
@@ -119,6 +129,14 @@ func (e *baseExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) erro
 	switch e.config.Encoding {
 	case EncodingJSON:
 		request, err = tr.MarshalJSON()
+	case EncodingNDJSON:
+		request, err = tr.MarshalJSON()
+		if err == nil {
+			// Trim spaces and append a newline so the payload conforms
+			// to NDJSON.
+			request = bytes.TrimSpace(request)
+			request = append(request, '\n')
+		}
 	case EncodingProto:
 		request, err = tr.MarshalProto()
 	default:
@@ -139,6 +157,12 @@ func (e *baseExporter) pushLogs(ctx context.Context, ld plog.Logs) error {
 	switch e.config.Encoding {
 	case EncodingJSON:
 		request, err = tr.MarshalJSON()
+	case EncodingNDJSON:
+		request, err = tr.MarshalJSON()
+		if err == nil {
+			request = bytes.TrimSpace(request)
+			request = append(request, '\n')
+		}
 	case EncodingProto:
 		request, err = tr.MarshalProto()
 	default:
@@ -160,6 +184,12 @@ func (e *baseExporter) pushProfiles(ctx context.Context, td pprofile.Profiles) e
 	switch e.config.Encoding {
 	case EncodingJSON:
 		request, err = tr.MarshalJSON()
+	case EncodingNDJSON:
+		request, err = tr.MarshalJSON()
+		if err == nil {
+			request = bytes.TrimSpace(request)
+			request = append(request, '\n')
+		}
 	case EncodingProto:
 		request, err = tr.MarshalProto()
 	default:
@@ -183,6 +213,8 @@ func (e *baseExporter) export(ctx context.Context, url string, request []byte, p
 	switch e.config.Encoding {
 	case EncodingJSON:
 		req.Header.Set("Content-Type", jsonContentType)
+	case EncodingNDJSON:
+		req.Header.Set("Content-Type", ndjsonContentType)
 	case EncodingProto:
 		req.Header.Set("Content-Type", protobufContentType)
 	default:
@@ -347,7 +379,10 @@ func (e *baseExporter) tracesPartialSuccessHandler(protoBytes []byte, contentTyp
 		if err != nil {
 			return fmt.Errorf("error parsing protobuf response: %w", err)
 		}
-	case jsonContentType:
+	case jsonContentType, ndjsonContentType:
+		if contentType == ndjsonContentType {
+			protoBytes = bytes.TrimSpace(protoBytes)
+		}
 		err := exportResponse.UnmarshalJSON(protoBytes)
 		if err != nil {
 			return fmt.Errorf("error parsing json response: %w", err)
@@ -377,7 +412,10 @@ func (e *baseExporter) metricsPartialSuccessHandler(protoBytes []byte, contentTy
 		if err != nil {
 			return fmt.Errorf("error parsing protobuf response: %w", err)
 		}
-	case jsonContentType:
+	case jsonContentType, ndjsonContentType:
+		if contentType == ndjsonContentType {
+			protoBytes = bytes.TrimSpace(protoBytes)
+		}
 		err := exportResponse.UnmarshalJSON(protoBytes)
 		if err != nil {
 			return fmt.Errorf("error parsing json response: %w", err)
@@ -407,7 +445,10 @@ func (e *baseExporter) logsPartialSuccessHandler(protoBytes []byte, contentType 
 		if err != nil {
 			return fmt.Errorf("error parsing protobuf response: %w", err)
 		}
-	case jsonContentType:
+	case jsonContentType, ndjsonContentType:
+		if contentType == ndjsonContentType {
+			protoBytes = bytes.TrimSpace(protoBytes)
+		}
 		err := exportResponse.UnmarshalJSON(protoBytes)
 		if err != nil {
 			return fmt.Errorf("error parsing json response: %w", err)
@@ -437,7 +478,10 @@ func (e *baseExporter) profilesPartialSuccessHandler(protoBytes []byte, contentT
 		if err != nil {
 			return fmt.Errorf("error parsing protobuf response: %w", err)
 		}
-	case jsonContentType:
+	case jsonContentType, ndjsonContentType:
+		if contentType == ndjsonContentType {
+			protoBytes = bytes.TrimSpace(protoBytes)
+		}
 		err := exportResponse.UnmarshalJSON(protoBytes)
 		if err != nil {
 			return fmt.Errorf("error parsing json response: %w", err)

--- a/exporter/otlphttpexporter/otlp_test.go
+++ b/exporter/otlphttpexporter/otlp_test.go
@@ -581,6 +581,7 @@ func TestPartialResponse_missingHeaderButHasBody(t *testing.T) {
 	}{
 		{contentType: protobufContentType},
 		{contentType: jsonContentType},
+		{contentType: ndjsonContentType},
 	}
 
 	telemetryTypes := []struct {
@@ -621,6 +622,11 @@ func TestPartialResponse_missingHeaderButHasBody(t *testing.T) {
 				switch ct.contentType {
 				case jsonContentType:
 					data, err = serializer.MarshalJSON()
+				case ndjsonContentType:
+					data, err = serializer.MarshalJSON()
+					if err == nil {
+						data = append(data, '\n')
+					}
 				case protobufContentType:
 					data, err = serializer.MarshalProto()
 				default:
@@ -654,6 +660,7 @@ func TestPartialResponse_missingHeaderAndBody(t *testing.T) {
 	}{
 		{contentType: protobufContentType},
 		{contentType: jsonContentType},
+		{contentType: ndjsonContentType},
 	}
 
 	telemetryTypes := []struct {
@@ -722,6 +729,7 @@ func TestPartialSuccess_shortContentLengthHeader(t *testing.T) {
 	}{
 		{contentType: protobufContentType},
 		{contentType: jsonContentType},
+		{contentType: ndjsonContentType},
 	}
 
 	telemetryTypes := []struct {
@@ -762,6 +770,11 @@ func TestPartialSuccess_shortContentLengthHeader(t *testing.T) {
 				switch ct.contentType {
 				case jsonContentType:
 					data, err = serializer.MarshalJSON()
+				case ndjsonContentType:
+					data, err = serializer.MarshalJSON()
+					if err == nil {
+						data = append(data, '\n')
+					}
 				case protobufContentType:
 					data, err = serializer.MarshalProto()
 				default:
@@ -790,6 +803,7 @@ func TestPartialSuccess_longContentLengthHeader(t *testing.T) {
 	}{
 		{contentType: protobufContentType},
 		{contentType: jsonContentType},
+		{contentType: ndjsonContentType},
 	}
 
 	telemetryTypes := []struct {
@@ -846,6 +860,11 @@ func TestPartialSuccess_longContentLengthHeader(t *testing.T) {
 				switch ct.contentType {
 				case jsonContentType:
 					data, err = serializer.MarshalJSON()
+				case ndjsonContentType:
+					data, err = serializer.MarshalJSON()
+					if err == nil {
+						data = append(data, '\n')
+					}
 				case protobufContentType:
 					data, err = serializer.MarshalProto()
 				default:
@@ -1028,6 +1047,11 @@ func TestEncoding(t *testing.T) {
 			name:             "json_encoding",
 			encoding:         EncodingJSON,
 			expectedEncoding: "application/json",
+		},
+		{
+			name:             "ndjson_encoding",
+			encoding:         EncodingNDJSON,
+			expectedEncoding: "application/x-ndjson",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- support `ndjson` encoding in `otlphttpexporter`
- document new encoding option
- handle ndjson in export requests and responses
- cover ndjson in unit tests
- refine ndjson handling

## Testing
- `go test ./...` *(fails: cannot download modules)*